### PR TITLE
Replace assert@sourceryinstitute with assert@BerkeleyLab

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2872,9 +2872,6 @@
 [submodule "asimov-ccs"]
 	path = asimov-ccs@asimovpp
 	url = ssh://git@github.com/asimovpp/asimov-ccs
-[submodule "assert"]
-	path = assert@sourceryinstitute
-	url = ssh://git@github.com/sourceryinstitute/assert
 [submodule "assert-fortran"]
 	path = assert-fortran@alecksandr26
 	url = ssh://git@github.com/alecksandr26/assert-fortran


### PR DESCRIPTION
The folks at Berkeley Lab pointed me to the updated version.